### PR TITLE
Fix font-weight aliased when animation

### DIFF
--- a/source/stylesheets/application.css.sass
+++ b/source/stylesheets/application.css.sass
@@ -6,3 +6,9 @@
 @import "base/*"
 @import "components/*"
 @import "modules/*"
+
+body
+  text-rendering: optimizeLegibility
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: grayscale
+  


### PR DESCRIPTION
I believe it solved #14 as well

Some blogs has mentioned this hack: 
https://maximilianhoffmann.com/posts/better-font-rendering-on-osx

Even [Apple](https://www.apple.com/iphone/compare/) has this fix.
![screen shot 2015-12-08 at 10 19 08 am](https://cloud.githubusercontent.com/assets/2673743/11646083/40028082-9d95-11e5-8224-7b623cb75f60.png)
